### PR TITLE
Add gacha history show command

### DIFF
--- a/src/commands/gachaHistory/index.ts
+++ b/src/commands/gachaHistory/index.ts
@@ -1,12 +1,15 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import type { CommandInteraction } from 'discord.js';
+import * as show from './subcommands/show';
 import * as toggle from './subcommands/toggle';
 
 const subcommands: Map<string, BotTypes.Subcommand> = new Map();
 subcommands
+    .set(show.data.name, show)
     .set(toggle.data.name, toggle);
 
 export const data = new SlashCommandBuilder()
+    .addSubcommand(show.data)
     .addSubcommand(toggle.data)
     .setName('gachahistory')
     .setDescription('Track your gachas');

--- a/src/commands/gachaHistory/subcommands/show.ts
+++ b/src/commands/gachaHistory/subcommands/show.ts
@@ -1,0 +1,145 @@
+import { bold, inlineCode, italic, SlashCommandSubcommandBuilder, time } from '@discordjs/builders';
+import dayjs from 'dayjs';
+import { CommandInteraction, MessageEmbed } from 'discord.js';
+import { cleanCharacterName } from 'laifutil';
+import { MISSING_INFO } from '../../../constants';
+import { Character, User } from '../../../model';
+import { Pages } from '../../../structures';
+import { isGachaResultBadgeSchema, isGachaResultCharacterSchema } from '../../../util';
+
+interface GachaResult {
+    result: BotTypes.GachaResultSchema;
+    character?: BotTypes.LeanCharacterDocument;
+}
+
+type SortOption = 'top_influence' | 'low_influence';
+
+export const data = new SlashCommandSubcommandBuilder()
+    .addStringOption(option =>
+        option
+            .setChoices(
+                { name: 'Top Influence', value: 'top_influence' },
+                { name: 'Low Influence', value: 'low_influence' },
+            )
+            .setName('sort')
+            .setDescription('Sort history when viewing'),
+    )
+    .setName('show')
+    .setDescription('View your gacha history');
+
+export async function execute(interaction: CommandInteraction, unique: BotTypes.Unique) {
+    await interaction.deferReply();
+
+    const { options, user } = interaction;
+
+    const sortOption = options.getString('sort') as SortOption | null;
+
+    const targetUser = await User.findOne({ id: user.id })
+        .select('gachaHistory.history')
+        .lean() as BotTypes.LeanUserDocument | null;
+
+    if (targetUser) {
+        const arr = await toGachaResultArray(targetUser.gachaHistory.history);
+        const sortedArr = sort(arr, sortOption);
+        const lines = createLines(sortedArr);
+
+        const embed = new MessageEmbed()
+            .setAuthor({ name: user.username, iconURL: user.displayAvatarURL() })
+            .setTitle(`Gacha History - ${user.username}`);
+
+        const pages = new Pages({
+            interaction,
+            unique,
+            itemName: 'Gachas',
+            lines,
+            embed,
+        });
+
+        pages.start({ deferred: true });
+    } else {
+        await interaction.editReply({ content: `Could not find gacha history for ${user.username}` });
+    }
+}
+
+// eslint-disable-next-line
+export function isPermitted(_interaction: CommandInteraction) {
+    return true;
+}
+
+function toGachaResultArray(arr: BotTypes.GachaResultSchema[]): Promise<GachaResult[]> {
+    const promises = arr.map(async result => {
+        const temp: GachaResult = { result };
+
+        if (isGachaResultCharacterSchema(result)) {
+            const character = await Character.findOne({ id: result.globalId })
+                .lean() as BotTypes.LeanCharacterDocument | null;
+
+            if (character) {
+                temp.character = character;
+            }
+        }
+
+        return temp;
+    });
+
+    return Promise.all(promises);
+}
+
+function compareDate(a: Date, b: Date): number {
+    return dayjs(a).isAfter(dayjs(b)) ? -1 : 1;
+}
+
+function sort(arr: GachaResult[], sortOption: SortOption | null): GachaResult[] {
+    let ret: GachaResult[];
+
+    if (sortOption === 'top_influence' || sortOption === 'low_influence') {
+        const mul = sortOption === 'top_influence' ? -1 : 1;
+
+        ret = arr
+            .filter(e => isGachaResultCharacterSchema(e.result))
+            .sort((a, b) => {
+                const charA = a.character;
+                const charB = b.character;
+
+                if (charA && charB) {
+                    if (charA.influence === charB.influence) {
+                        return compareDate(a.result.createdAt, b.result.createdAt);
+                    } else {
+                        return (charA.influence - charB.influence) * mul;
+                    }
+                } else if (charA) {
+                    return -1;
+                } else if (charB) {
+                    return 1;
+                } else {
+                    return compareDate(a.result.createdAt, b.result.createdAt);
+                }
+            });
+    } else {
+        ret = arr.slice().sort((a, b) => compareDate(a.result.createdAt, b.result.createdAt));
+    }
+
+    return ret;
+}
+
+function createLines(arr: GachaResult[]): string[] {
+    const ret = arr.map(e => {
+        if (isGachaResultCharacterSchema(e.result)) {
+            let characterInfo: string = MISSING_INFO;
+
+            if (e.character) {
+                characterInfo = `${cleanCharacterName(e.character.name)}・`
+                    + `${bold(`${e.character.influence}`)} <:inf:755213119055200336>`;
+            }
+
+            return `${e.result.uniqueId} [${e.result.rarity}] ${characterInfo} `
+                + `${inlineCode(`(${e.result.globalId})`)}・${time(e.result.createdAt, 'f')}`;
+        } else if (isGachaResultBadgeSchema(e.result)) {
+            return italic('BADGE SUPPORT WIP');
+        } else {
+            return italic('ERROR');
+        }
+    });
+
+    return ret;
+}

--- a/src/commands/gachaHistory/subcommands/show.ts
+++ b/src/commands/gachaHistory/subcommands/show.ts
@@ -132,8 +132,11 @@ function createLines(arr: GachaResult[]): string[] {
                     + `${bold(`${e.character.influence}`)} <:inf:755213119055200336>`;
             }
 
-            return `${e.result.uniqueId} [${e.result.rarity}] ${characterInfo} `
-                + `${inlineCode(`(${e.result.globalId})`)}・${time(e.result.createdAt, 'f')}`;
+            // TODO delete later
+            const image = e.result.image ?? '?';
+
+            return `${e.result.uniqueId} [${e.result.rarity}] #${image} ${characterInfo} `
+                + `${inlineCode(`(${e.result.globalId})`)}・${time(e.result.createdAt, 'R')}`;
         } else if (isGachaResultBadgeSchema(e.result)) {
             return italic('BADGE SUPPORT WIP');
         } else {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -16,6 +16,7 @@ const everyoneCommands = [
     'reminder',
     'wishlist',
     'gachahistory toggle',
+    'gachahistory show',
 ].sort().join(', ');
 
 export const data = new SlashCommandBuilder()

--- a/src/model/User.ts
+++ b/src/model/User.ts
@@ -15,6 +15,7 @@ const gachaResultSchema = new Schema({
     globalId: { type: Number },
     uniqueId: { type: Number },
     rarity: { type: String },
+    image: { type: Number },
     tier: { type: Number },
     badgeId: { type: Number },
 }, { timestamps: true });

--- a/src/plugin/gachaHistory.ts
+++ b/src/plugin/gachaHistory.ts
@@ -21,6 +21,7 @@ export async function run(newMessage: Message | PartialMessage, oldMessage: Mess
                 globalId: embed.globalId,
                 uniqueId: embed.uniqueId,
                 rarity: embed.rarity.SYMBOL,
+                image: embed.image.currentNumber,
             };
 
             user.gachaHistory.history.push(schemaData);

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -91,6 +91,7 @@ declare global {
             globalId: number;
             uniqueId: number;
             rarity: string;
+            image: number;
         }
 
         interface BaseGachaResultSchema extends

--- a/src/util/gachaResult.ts
+++ b/src/util/gachaResult.ts
@@ -1,0 +1,9 @@
+export function isGachaResultCharacterSchema(result: BotTypes.GachaResultSchema):
+    result is BotTypes.GachaResultSchema & BotTypes.GachaResultCharacterSchema {
+    return result.gachaType === 'character';
+}
+
+export function isGachaResultBadgeSchema(result: BotTypes.GachaResultSchema):
+    result is BotTypes.GachaResultSchema & BotTypes.GachaResultBadgeSchema {
+    return result.gachaType === 'badge';
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -4,3 +4,4 @@ export * from './string';
 export * as CharacterSchema from './characterSchema';
 export * from './error';
 export * from './user';
+export * from './gachaResult';

--- a/src/util/user.ts
+++ b/src/util/user.ts
@@ -7,5 +7,8 @@ export async function findUser(id: string): Promise<BotTypes.UserDocument> {
         return userTemp as BotTypes.UserDocument;
     }
 
-    return new User({ id }) as BotTypes.UserDocument;
+    const user = new User({ id }) as BotTypes.UserDocument;
+    await user.save();
+
+    return user;
 }


### PR DESCRIPTION
- refractored wishlist command
- changed custom id to obtain unique strings for command interactions
- removed add/remove command, added modify command, moved page button interaction into util/pages
- added types file, removed redundant code, rename files
- fix modal submission to not crash if no modal was sent in time
- remove mongoose
- added arguments for info script
- Switched to mongodb for character database
- Finished mongodb transition
- Removed old database related files
- Use lean for readonly operations from mongo
- Refractored code, created Pages structure, modulate modify command
- Updated dependencies
- Added character updates through gacha, view, and burn commands
- Update dependencies
- Add reminder.drop to user schema
- Improve typing definitions, added PartialUserSchema
- Update character schema: add require to fields
- Fix gacha embed check for wishlist plugin
- Added reminder command
- Added drop reminder functionality
- Added medal drop reminder
- Check for undefined embed
- Update help command
- Fix medal drop guild id check
- Switched to dotenv for config
- Added readme
- Fix help command description
- Reword sentence
- Mention deploy commands
- Integrate timestamps with schemas
- Add gacha history to User schema
- Added gacha history toggle command
- Add unique to command execute parameters
- Add gacha history plugin
- Added gacha history show command
- Redefine GachaResultSchema
